### PR TITLE
add `has-preprocess-tab` attribute to fetch-button

### DIFF
--- a/grails-app/views/layouts/_heatmap.gsp
+++ b/grails-app/views/layouts/_heatmap.gsp
@@ -45,7 +45,8 @@
                     summary-data="fetch.scriptResults"
                     all-samples="common.totalSamples"
                     allowed-cohorts="[1,2]"
-                    number-of-rows="common.numberOfRows">
+                    number-of-rows="common.numberOfRows"
+                    has-preprocess-tab="true">
             </fetch-button>
             <br/>
             <summary-stats summary-data="fetch.scriptResults"></summary-stats>

--- a/test/unit/javascript/fetchButtonDirectiveTests.js
+++ b/test/unit/javascript/fetchButtonDirectiveTests.js
@@ -22,7 +22,8 @@ describe('fetchButton', function() {
 
         $rootScope.conceptMap = {};
         $rootScope.allowedCohorts = [];
-        var html = '<fetch-button concept-map="conceptMap" allowed-cohorts="allowedCohorts"></fetch-button>';
+        $rootScope.hasPreprocessTab = false;
+        var html = '<fetch-button concept-map="conceptMap" allowed-cohorts="allowedCohorts" has-preprocess-tab="hasPreprocessTab"></fetch-button>';
         element = $compile(angular.element(html))($rootScope);
         $rootScope.$digest();
     }));
@@ -50,11 +51,12 @@ describe('fetchButton', function() {
         }
     };
 
-    var _prepareScope = function(cohorts, allowedCohorts, showSummaryStats, conceptMap) {
+    var _prepareScope = function(cohorts, allowedCohorts, showSummaryStats, conceptMap, hasPreprocessTab) {
         spyOn(smartRUtils, 'countCohorts').and.returnValue(cohorts);
         element.isolateScope().allowedCohorts = String(allowedCohorts);
         element.isolateScope().showSummaryStats = showSummaryStats;
         element.isolateScope().conceptMap = conceptMap;
+        $rootScope.hasPreprocessTab = hasPreprocessTab;
         $rootScope.$digest();
     };
 
@@ -103,11 +105,7 @@ describe('fetchButton', function() {
     });
 
     it('should show `Task complete! Go to the "Preprocess" or "Run Analysis" tab to continue.`', function() {
-        // NOTE overriding parts of `beforeEach` here
-        var html = '<fetch-button concept-map="conceptMap" allowed-cohorts="allowedCohorts" has-preprocess-tab="true"></fetch-button>';
-        element = $compile(angular.element(html))($rootScope);
-        $rootScope.$digest();
-        _prepareScope(1, [1,2], true, {foo: {concepts: ['concept'], valid: true}});
+        _prepareScope(1, [1,2], true, {foo: {concepts: ['concept'], valid: true}}, true);
         _clickButton('resolve()', 'resolve({result: {allSamples: 1337, subsets: null}})');
         expect(element.find('span').text()).toBe('Task complete! Go to the "Preprocess" or "Run Analysis" tab to continue.');
         expect(element.isolateScope().running).toBe(false);

--- a/test/unit/javascript/fetchButtonDirectiveTests.js
+++ b/test/unit/javascript/fetchButtonDirectiveTests.js
@@ -87,13 +87,26 @@ describe('fetchButton', function() {
     it('should have the correct scope when successful without showSummaryStats', function() {
         _prepareScope(2, [2], false, {foo: {concepts: ['concept'], valid: true}});
         _clickButton('resolve()');
-        expect(element.find('span').text()).toBe('Task complete! Go to the "Preprocess" or "Run Analysis" tab to continue.');
+        expect(element.find('span').text()).toBe('Task complete! Go to the "Run Analysis" tab to continue.');
         expect(element.isolateScope().running).toBe(false);
         expect(element.isolateScope().loaded).toBe(true);
         expect(element.isolateScope().allSamples).toEqual(0);
     });
 
     it('should have the correct scope when successful with showSummaryStats', function() {
+        _prepareScope(1, [1,2], true, {foo: {concepts: ['concept'], valid: true}});
+        _clickButton('resolve()', 'resolve({result: {allSamples: 1337, subsets: null}})');
+        expect(element.find('span').text()).toBe('Task complete! Go to the "Run Analysis" tab to continue.');
+        expect(element.isolateScope().running).toBe(false);
+        expect(element.isolateScope().loaded).toBe(true);
+        expect(element.isolateScope().allSamples).toEqual(1337);
+    });
+
+    it('should show `Task complete! Go to the "Preprocess" or "Run Analysis" tab to continue.`', function() {
+        // NOTE overriding parts of `beforeEach` here
+        var html = '<fetch-button concept-map="conceptMap" allowed-cohorts="allowedCohorts" has-preprocess-tab="true"></fetch-button>';
+        element = $compile(angular.element(html))($rootScope);
+        $rootScope.$digest();
         _prepareScope(1, [1,2], true, {foo: {concepts: ['concept'], valid: true}});
         _clickButton('resolve()', 'resolve({result: {allSamples: 1337, subsets: null}})');
         expect(element.find('span').text()).toBe('Task complete! Go to the "Preprocess" or "Run Analysis" tab to continue.');

--- a/web-app/js/smartR/_angular/directives/fetchButton.js
+++ b/web-app/js/smartR/_angular/directives/fetchButton.js
@@ -19,7 +19,8 @@ window.smartRApp.directive('fetchButton', [
                 allSamples: '=?',
                 numberOfRows: '=?',
                 allowedCohorts: '=',
-                projection: '@?'
+                projection: '@?',
+                hasPreprocessTab: '=?'
             },
             templateUrl: $rootScope.smartRPath +  '/js/smartR/_angular/templates/fetchButton.html',
             link: function(scope, element) {
@@ -27,7 +28,11 @@ window.smartRApp.directive('fetchButton', [
                     template_msg = element.children()[1];
 
                 var _onSuccess = function() {
-                    template_msg.innerHTML = 'Task complete! Go to the "Preprocess" or "Run Analysis" tab to continue.';
+                    if (scope.hasPreprocessTab) {
+                        template_msg.innerHTML = 'Task complete! Go to the "Preprocess" or "Run Analysis" tab to continue.';
+                    } else {
+                        template_msg.innerHTML = 'Task complete! Go to the "Run Analysis" tab to continue.';
+                    }
                     scope.loaded = true;
                     template_btn.disabled = false;
                     scope.running = false;


### PR DESCRIPTION
By default show only the text `Go to the "Run Analysis" tab to continue.`,
"Preprocess" is only added to this text if `has-preprocess-tab` is true.
