### PR TITLE
optional alternative wait message for `run-button`

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -35,6 +35,7 @@ module.exports = function(config) {
             'web-app/js/smartR/_angular/services/smartRUtils.js',
             'web-app/js/smartR/_angular/services/rServeService.js',
             'web-app/js/smartR/_angular/directives/fetchButton.js',
+            'web-app/js/smartR/_angular/directives/runButton.js',
 
             // templates
             'web-app/js/smartR/_angular/templates/*.html',

--- a/test/unit/javascript/runButtonDirectiveTests.js
+++ b/test/unit/javascript/runButtonDirectiveTests.js
@@ -1,0 +1,40 @@
+'use strict';
+
+describe('runButton', function() {
+    var $compile,
+        $rootScope,
+        $httpBackend,
+        $q,
+        element,
+        smartRUtils,
+        rServeService;
+
+    beforeEach(module('smartRApp'));
+    beforeEach(module('smartRTemplates'));
+
+    beforeEach(inject(function(_$compile_, _$rootScope_, _$httpBackend_, _$q_, _smartRUtils_, _rServeService_) {
+        $compile = _$compile_;
+        $rootScope = _$rootScope_;
+        $httpBackend = _$httpBackend_;
+        $q = _$q_;
+        smartRUtils = _smartRUtils_;
+        rServeService = _rServeService_;
+
+        $rootScope.scriptResults = {};
+    }));
+
+    it('should show "Creating plot, please wait"', function() {
+        var html = '<run-button button-name="Create Plot" store-results-in="scriptResults" script-to-run="run"></run-button>';
+        element = $compile(angular.element(html))($rootScope);
+        $rootScope.$digest();
+        expect(element.isolateScope().waitMessage).toEqual("Creating plot, please wait");
+    });
+
+    it('should show "Running R-script, please wait"', function() {
+        var html = '<run-button button-name="Create Plot" store-results-in="scriptResults" script-to-run="run" wait-message="Running R-script, please wait"></run-button>';
+        element = $compile(angular.element(html))($rootScope);
+        $rootScope.$digest();
+        expect(element.isolateScope().waitMessage).toEqual("Running R-script, please wait");
+    });
+});
+

--- a/web-app/js/smartR/_angular/directives/runButton.js
+++ b/web-app/js/smartR/_angular/directives/runButton.js
@@ -15,11 +15,15 @@ window.smartRApp.directive('runButton', [
                 script: '@scriptToRun',
                 name: '@buttonName',
                 filename: '@?',
-                params: '=?argumentsToUse'
+                params: '=?argumentsToUse',
+                waitMessage: '@?'
             },
             templateUrl: $rootScope.smartRPath + '/js/smartR/_angular/templates/runButton.html',
             link: function(scope, element) {
                 var params = scope.params ? scope.params : {};
+                if (!scope.waitMessage) {
+                    scope.waitMessage = 'Creating plot, please wait';
+                }
 
                 var template_btn = element.children()[0],
                     template_msg = element.children()[1];
@@ -59,7 +63,7 @@ window.smartRApp.directive('runButton', [
                     scope.storage = {};
                     scope.disabled = true;
                     scope.running = true;
-                    template_msg.innerHTML = 'Creating plot, please wait <span class="blink_me">_</span>';
+                    template_msg.innerHTML = scope.waitMessage + ' <span class="blink_me">_</span>';
 
                     rServeService.startScriptExecution({
                         taskType: scope.script,


### PR DESCRIPTION
`run-button` by default shows `Creating plot, please wait` when running an
R-script. This message can be changed by adding the optional attribute
`wait-message`. Added unit tests for both behaviours.
