### PR TITLE
SmartR: Re-try to connect to Rserve on demand.

### DIFF
--- a/src/groovy/heim/tasks/RScriptExecutionTaskFactory.groovy
+++ b/src/groovy/heim/tasks/RScriptExecutionTaskFactory.groovy
@@ -55,10 +55,7 @@ class RScriptExecutionTaskFactory implements TaskFactory {
 
     @Override
     Task createTask(String taskName, Map<String, Object> arguments) {
-        if (!rScriptsSynchronizer.wasCopySuccessful()) {
-            throw new IllegalStateException(
-                    "Cannot continue because R scripts were not successfully copied")
-        }
+        rScriptsSynchronizer.ensureScriptsAreCopied()
         try {
             File fileToLoad = calculateRemoteScriptPath(taskName)
 


### PR DESCRIPTION
There is a smartr service that copies files to the rserve side on the application start.
When there was a problem copying the files (e.g. rserve is down) it tried to repeat operation 10 times. After that, it gave up.

This PR adds logic to copy the files on each smartR interaction if they were not copied yet.